### PR TITLE
don't parse 'extra' if unset

### DIFF
--- a/omdclient/__init__.py
+++ b/omdclient/__init__.py
@@ -243,8 +243,9 @@ def createHost(host, arghash):
         if arghash['ip'] != 'UNSET':
             attributes['ipaddress'] = arghash['ip']
     if 'extra' in arghash:
-        import shlex
-        attributes.update(dict(token.split('=') for token in shlex.split(arghash['extra'])))
+        if arghash['extra'] != 'UNSET' and '=' in arghash['extra']:
+          import shlex
+          attributes.update(dict(token.split('=') for token in shlex.split(arghash['extra'])))
     request['attributes'] = attributes
 
     url = generateUrl ('add_host', arghash)


### PR DESCRIPTION
...this makes passing 'extra' optional again, as without this check the parser will error out because of missing params.
This also adds a check to make sure the string is parseable by shlex.