### PR TITLE
Add option to filter nagios host list by monitored site

### DIFF
--- a/omdclient/__init__.py
+++ b/omdclient/__init__.py
@@ -314,6 +314,19 @@ def listHosts(arghash):
     response = loadUrl(url, '')
     return processUrlResponse(response, arghash['debug'])
 
+def listHostsFiltered(filter, arghash):
+    """
+    List all hosts filtered by site.
+    """
+    url = generateUrl('get_all_hosts', arghash)
+    response = loadUrl(url, '')
+    status, response = processUrlResponse(response, arghash['debug'])
+    response_filtered = dict(response)
+    for h in response:
+        if response[h].get('attributes',{}).get('site','') != filter:
+            del response_filtered[h]
+    return status, response_filtered
+
 def deleteHost(host, arghash):
     """
     Remove a host from check_mk.
@@ -400,11 +413,11 @@ def generateNagiosUrl (action, args):
         if 'start' in args.keys(): start = args['start']
         else:                      start = datetime.datetime.now()
         if 'end' in args.keys():   end   = args['end']
-        else:             
+        else:
             end = start + datetime.timedelta(hours=int(args['hours']))
 
         url_parts['_down_custom']    = 'Custom+time_range'
-        url_parts['_down_from_date'] = start.date() 
+        url_parts['_down_from_date'] = start.date()
         url_parts['_down_from_time'] = start.strftime('%H:%M')
         url_parts['_down_to_date']   = end.date()
         url_parts['_down_to_time']   = end.strftime('%H:%M')
@@ -419,7 +432,7 @@ def generateNagiosUrl (action, args):
             url_parts['view_name'] = 'service'
         else:
             raise Exception('invalid downtime type: %s' % args['type'])
-        
+
     elif action == 'ack':
         url_parts['_transid'] = '-1'
         url_parts['_do_confirm'] = 'yes'

--- a/usr/bin/omd-host-crud
+++ b/usr/bin/omd-host-crud
@@ -39,10 +39,12 @@ def printReport(result, opt):
     """
     att = result['attributes']
     print result['hostname']
-    if att['alias']:
+    if att.get('alias', None):
         print "  %-20s %s" % ('alias', att['alias'])
-    print "  %-20s %s" % ('cmk_role',     att['tag_role'])
-    print "  %-20s %s" % ('cmk_instance', att['tag_instance'])
+    if att.get('tag_role', None):
+        print "  %-20s %s" % ('cmk_role',     att['tag_role'])
+    if att.get('tag_instance', None):
+        print "  %-20s %s" % ('cmk_instance', att['tag_instance'])
     print "  %-20s %s" % ('folder',       result['path'])
 
 #########################################################################

--- a/usr/bin/omd-nagios-hostlist
+++ b/usr/bin/omd-nagios-hostlist
@@ -34,12 +34,17 @@ def main():
     p = omdclient.generateParser(text, usage_text, config)
     p.add_option('--verbose', dest='verbose', action="store_true",
         default=False, help='print more status information')
+    p.add_option('--filter-site', dest='filter_site',
+        default=False, help='Filter result by monitored site. Default: disabled')
     opt, args = p.parse_args()
 
     argdict = omdclient.parserArgDict(opt)
 
     try:
-        hosts = omdclient.listHosts(argdict)
+        if opt.filter_site:
+            hosts = omdclient.listHostsFiltered(opt.filter_site, argdict)
+        else:
+            hosts = omdclient.listHosts(argdict)
         h = []
         for i in hosts[1]:
             if i: h.append(i)
@@ -85,6 +90,10 @@ If set, print debugging information.
 =item B<--help>
 
 Print this information and exit.
+
+=item B<--filter-site>
+
+Filter host by site monitored. Default: disabled
 
 =back
 


### PR DESCRIPTION
If we use omd-host-crud create HOSTNAME no additonal parameters are set, so we should not rely on it, when we read information of a host